### PR TITLE
feat: 상세페이지 조회 api 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "axios": "^1.4.0",
     "csv-parser": "^3.0.0",
     "iconv-lite": "^0.6.3",
-    "prisma": "^5.0.0",
+    "prisma": "^5.1.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { KakaoModule } from './kakao/kakao.module';
 import { ConfigModule } from '@nestjs/config';
 import { StoreModule } from './store/store.module';
+import { MapModule } from './map/map.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { StoreModule } from './store/store.module';
     PrismaModule,
     KakaoModule,
     StoreModule,
+    MapModule,
   ],
   controllers: [],
   providers: [],

--- a/src/map/map.controller.ts
+++ b/src/map/map.controller.ts
@@ -5,8 +5,8 @@ import { MapService } from './map.service';
 export class MapController {
   constructor(private readonly mapService: MapService) {}
 
-  @Get('/:detail')
-  getMapDetail(@Param('detail') id: string) {
+  @Get('/detail/:id')
+  getMapDetail(@Param('id') id: string) {
     return this.mapService.mapDetail(id);
   }
 }

--- a/src/map/map.controller.ts
+++ b/src/map/map.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { MapService } from './map.service';
+
+@Controller('map')
+export class MapController {
+  constructor(private readonly mapService: MapService) {}
+
+  @Get('/:detail')
+  getMapDetail(@Param('detail') id: string) {
+    return this.mapService.mapDetail(id);
+  }
+}

--- a/src/map/map.module.ts
+++ b/src/map/map.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class MapModule {}

--- a/src/map/map.module.ts
+++ b/src/map/map.module.ts
@@ -1,4 +1,11 @@
 import { Module } from '@nestjs/common';
+import { MapController } from './map.controller';
+import { MapService } from './map.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 
-@Module({})
+@Module({
+  imports: [PrismaModule],
+  controllers: [MapController],
+  providers: [MapService],
+})
 export class MapModule {}

--- a/src/map/map.service.ts
+++ b/src/map/map.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class MapService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async mapDetail(id: string) {
+    let store;
+    try {
+      store = await this.prismaService.store.findFirstOrThrow({
+        where: {
+          id,
+        },
+      });
+    } catch (e) {
+      if (e.code === 'P2025') {
+        throw new NotFoundException(['존재하는 가맹점 명이 없습니다.']);
+      }
+    }
+
+    return {
+      name: store.name,
+      latitude: store.latitude,
+      longitude: store.longitude,
+      roadNameAddress: store.roadNameAddress,
+      fullAddress: store.fullAddress,
+      phoneNumber: store.phoneNumber,
+    };
+  }
+}

--- a/src/map/map.service.ts
+++ b/src/map/map.service.ts
@@ -19,12 +19,25 @@ export class MapService {
       }
     }
 
+    let storeLocation;
+    try {
+      storeLocation = await this.prismaService.storeLocation.findFirstOrThrow({
+        where: {
+          store,
+        },
+      });
+    } catch (e) {
+      if (e.code === 'P2025') {
+        throw new NotFoundException(['존재하는']);
+      }
+    }
+
     return {
       name: store.name,
-      latitude: store.latitude,
-      longitude: store.longitude,
-      roadNameAddress: store.roadNameAddress,
-      fullAddress: store.fullAddress,
+      latitude: storeLocation.latitude,
+      longitude: storeLocation.longitude,
+      roadNameAddress: storeLocation.roadNameAddress,
+      fullAddress: storeLocation.fullAddress,
       phoneNumber: store.phoneNumber,
     };
   }

--- a/src/map/map.service.ts
+++ b/src/map/map.service.ts
@@ -28,7 +28,7 @@ export class MapService {
       });
     } catch (e) {
       if (e.code === 'P2025') {
-        throw new NotFoundException(['존재하는']);
+        throw new NotFoundException(['존재하는 가맹점 명이 없습니다.']);
       }
     }
 

--- a/src/map/map.service.ts
+++ b/src/map/map.service.ts
@@ -23,7 +23,7 @@ export class MapService {
     try {
       storeLocation = await this.prismaService.storeLocation.findFirstOrThrow({
         where: {
-          store,
+          id: store.locationId,
         },
       });
     } catch (e) {

--- a/src/map/map.service.ts
+++ b/src/map/map.service.ts
@@ -32,8 +32,22 @@ export class MapService {
       }
     }
 
+    let category;
+    try {
+      category = await this.prismaService.category.findFirstOrThrow({
+        where: {
+          code: store.categoryCode,
+        },
+      });
+    } catch (e) {
+      if (e.code === 'P2025') {
+        throw new NotFoundException(['존재하는 가맹점 명이 없습니다.']);
+      }
+    }
+
     return {
       name: store.name,
+      category: category.name,
       latitude: storeLocation.latitude,
       longitude: storeLocation.longitude,
       roadNameAddress: storeLocation.roadNameAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -798,10 +798,10 @@
   resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz#b36eda5620872d3fac810c302a7e46cf41daa033"
   integrity sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ==
 
-"@prisma/engines@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.0.0.tgz#5249650eabe77c458c90f2be97d8210353c2e22e"
-  integrity sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==
+"@prisma/engines@5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.1.1.tgz#9c26d209f93a563e048eab63b1976f222f1707d0"
+  integrity sha512-NV/4nVNWFZSJCCIA3HIFJbbDKO/NARc9ej0tX5S9k2EVbkrFJC4Xt9b0u4rNZWL4V+F5LAjvta8vzEUw0rw+HA==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -3878,12 +3878,12 @@ pretty-format@^29.0.0, pretty-format@^29.6.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prisma@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.0.0.tgz#f6571c46dc2478172cb7bc1bb62d74026a2c2630"
-  integrity sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==
+prisma@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.1.1.tgz#8f5c0f9467a828746cb94f846d694dc7b7481a9e"
+  integrity sha512-WJFG/U7sMmcc6TjJTTifTfpI6Wjoh55xl4AzopVwAdyK68L9/ogNo8QQ2cxuUjJf/Wa82z/uhyh3wMzvRIBphg==
   dependencies:
-    "@prisma/engines" "5.0.0"
+    "@prisma/engines" "5.1.1"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
가맹점에 대한 API 중 ‘가맹점의 상세페이지‘를 호출하는 로직을 작성했습니다
얻고자 하는 가맹점에 대한 ‘가맹점 명‘, ‘위도‘, ‘경도‘, ‘도로명 주소‘, ‘지번 주소‘, ‘전화번호‘를 얻을 수 있습니다.
만약 해당되는 가맹점이 없다면 ‘존재하는 가맹점 명이 없습니다.’가 뜹니다.