### PR TITLE
fix: 가맹점 데이터 저장 로직 수정

### DIFF
--- a/src/common/multer.options.factory.ts
+++ b/src/common/multer.options.factory.ts
@@ -1,7 +1,7 @@
 import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
 import { diskStorage } from 'multer';
 import { existsSync, mkdirSync } from 'fs';
-import { basename, extname, join } from 'path';
+import { extname, join } from 'path';
 
 export function multerOptionsFactory(): MulterOptions {
   let count = 0;
@@ -18,8 +18,7 @@ export function multerOptionsFactory(): MulterOptions {
 
       filename(req, file, done) {
         const ext = extname(file.originalname);
-        const filename = basename(file.originalname, ext);
-        done(null, `${filename}${count}${ext}`);
+        done(null, `seoulStoreInfo${count}${ext}`);
         count += 1;
       },
     }),

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -49,7 +49,7 @@ export class StoresService {
   }
 
   async parseCsv() {
-    const absoluteFilePath = `uploads/seoulStoreInf${count}.csv`;
+    const absoluteFilePath = `uploads/seoulStoreInfo${count}.csv`;
     count += 1;
 
     if (!absoluteFilePath) {

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -52,6 +52,12 @@ export class StoresService {
     const absoluteFilePath = `uploads/seoulStoreInf${count}.csv`;
     count += 1;
 
+    if (!absoluteFilePath) {
+      throw new NotFoundException([
+        `seoulStoreInfo${count}.cvs 파일이 존재하지 않습니다.`,
+      ]);
+    }
+
     fs.createReadStream(absoluteFilePath)
       .pipe(iconv.decodeStream('euc-kr'))
       .pipe(csvParser())
@@ -84,9 +90,15 @@ export class StoresService {
             });
           }
         } catch (e) {
-          console.error(e);
+          throw new InternalServerErrorException([
+            '데이터를 저장하는 과정에서 알 수 없는 오류가 발생했습니다.',
+          ]);
         }
       });
+
+    return {
+      message: ['데이터를 모두 정상적으로 저장했습니다.'],
+    };
   }
 
   async getStoreData(

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -30,7 +30,7 @@ export class StoresService {
       console.log(store.code);
       return store.code;
     } catch (e) {
-      console.log(e);
+      return 'FD';
     }
   }
 


### PR DESCRIPTION
- 데이터 저장 로직에 Response Body 추가했습니다.
- 기존에 정해놓은 카테고리 값들과 다른 업종 데이터가 csv 파일 안에 있는 걸 발견하여, 만약 업종에 대한 카테고리 코드를 찾아내지 못 하면 '기타'로 분류하여 보여주기로 했습니다.
- 업로드해서 저장할 파일명을 seoulStoreInf 에서 seoulStoreInfo 로 수정했습니다.