### PR TITLE
feat: 서울 외 가맹점 정보 제외시키기

### DIFF
--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -70,8 +70,8 @@ export class StoresService {
           if (store) {
             const location = await this.prismaService.location.create({
               data: {
-                latitude: +store.latitude,
-                longitude: +store.longitude,
+                latitude: store.latitude,
+                longitude: store.longitude,
                 fullAddress: await this.removeDuplicateStr(
                   store.roadNameAddress,
                   store.fullAddress,


### PR DESCRIPTION
- 카카오 API 에서 가맹점 명으로 검색하면서 서울 밖에 있는 가맹점 정보를 가져오는 이슈가 있었습니다.
- 서비스 지역인 서초구, 강남구를 포함하는 위도/경도의 최대, 최솟값을 구해와서 그 범위 내에 있는 가맹점들만 저장하도록 수정했습니다.