### PR TITLE
fix: 가맹점 위치 범위 정확히 한정 짓기 + 범위 확장

### DIFF
--- a/src/kakao/kakao.service.ts
+++ b/src/kakao/kakao.service.ts
@@ -22,11 +22,18 @@ export class KakaoService {
       if (data) {
         const longitude = new Decimal(data.x);
         const latitude = new Decimal(data.y);
+
+        const districts = [
+          '서울 강남구',
+          '서울 서초구',
+          '서울 동작구',
+          '서울 관악구',
+        ];
+
         if (
-          longitude.lessThanOrEqualTo(127.1378545233667) &&
-          longitude.greaterThanOrEqualTo(126.95724345345953) &&
-          latitude.lessThanOrEqualTo(37.56669609415292) &&
-          latitude.greaterThanOrEqualTo(37.33639771464528)
+          districts.some((district) =>
+            data.road_address_name.startsWith(district),
+          )
         ) {
           const storeInfo: StoreInfo = {
             longitude: longitude,
@@ -35,7 +42,6 @@ export class KakaoService {
             fullAddress: data.address_name,
             phoneNumber: data.phone || null,
           };
-
           return storeInfo;
         }
       } else {


### PR DESCRIPTION
- 강남, 서초 -> 강남, 서초, 동작, 관악구로 가맹점 범위 확장
- 위도, 경도로 가맹점 위치 범위를 한정 지었었는데, 그래도 타 지역 정보를 저장한다는 이슈 발생
   -> 서울 강남구, 서초구, 동작구, 관악구 데이터만 저장할 수 있게 수정